### PR TITLE
Update object lists from abapedia repos

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -410,7 +410,7 @@
       "ignoreExceptions": true,
       "ignoreGlobalClassDefinition": false,
       "ignoreGlobalInterface": false,
-      "selectionScreenBlockIndentation": false,
+      "selectionScreenBlockIndentation": true,
       "severity": "Error"
     },
     "inline_data_old_versions": {

--- a/src/zabapedia_object_existence.prog.abap
+++ b/src/zabapedia_object_existence.prog.abap
@@ -19,13 +19,13 @@
 REPORT zabapedia_object_existence.
 
 SELECTION-SCREEN BEGIN OF BLOCK b1 WITH FRAME.
-PARAMETERS:
-  p_repo   TYPE string LOWER CASE DEFAULT 'steampunk-2305-api'.
+  PARAMETERS
+    p_repo   TYPE string LOWER CASE DEFAULT 'steampunk-2305-api'.
 SELECTION-SCREEN END OF BLOCK b1.
 SELECTION-SCREEN BEGIN OF BLOCK b2 WITH FRAME.
-PARAMETERS:
-  p_path   TYPE string LOWER CASE DEFAULT 'C:\Temp\',
-  p_file_o TYPE string LOWER CASE DEFAULT 'on_prem_<release>.json'.
+  PARAMETERS:
+    p_path   TYPE string LOWER CASE DEFAULT 'C:\Temp\',
+    p_file_o TYPE string LOWER CASE DEFAULT 'on_prem_<release>.json'.
 SELECTION-SCREEN END OF BLOCK b2.
 
 TYPES:
@@ -54,19 +54,19 @@ CLASS lcl_check DEFINITION.
         IMPORTING
           iv_repo        TYPE string
         RETURNING
-          value(rs_data) TYPE ty_check
+          VALUE(rs_data) TYPE ty_check
         RAISING
           zcx_abapgit_ajson_error,
 
       system
         RETURNING
-          value(rs_system) TYPE ty_check-system,
+          VALUE(rs_system) TYPE ty_check-system,
 
       compare
         IMPORTING
           it_tadir        TYPE ty_check-object_list
         RETURNING
-          value(rt_tadir) TYPE ty_check-object_list
+          VALUE(rt_tadir) TYPE ty_check-object_list
         RAISING
           zcx_abapgit_ajson_error,
 
@@ -87,16 +87,14 @@ CLASS lcl_check IMPLEMENTATION.
       lv_url      TYPE string,
       lv_data     TYPE string,
       lv_object   TYPE string,
-      lt_objects TYPE string_table,
+      lt_objects  TYPE string_table,
       ls_object   TYPE ty_tadir,
       li_agent    TYPE REF TO zif_abapgit_http_agent,
       li_response TYPE REF TO zif_abapgit_http_response,
       li_json     TYPE REF TO zif_abapgit_ajson,
       lx_error    TYPE REF TO zcx_abapgit_exception.
 
-    FIELD-SYMBOLS <ls_object> LIKE LINE OF rs_data-object_list.
-
-    lv_url   = |https://raw.githubusercontent.com/abapedia/{ iv_repo }/main/src/_status.json|.
+    lv_url = |https://raw.githubusercontent.com/abapedia/{ iv_repo }/main/src/_status.json|.
 
     li_agent = zcl_abapgit_factory=>get_http_agent( ).
 

--- a/src/zabapedia_object_existence.prog.xml
+++ b/src/zabapedia_object_existence.prog.xml
@@ -12,7 +12,7 @@
    <TPOOL>
     <item>
      <ID>R</ID>
-     <ENTRY>abapPedia Object Existence</ENTRY>
+     <ENTRY>abapedia Object Existence</ENTRY>
      <LENGTH>26</LENGTH>
     </item>
     <item>

--- a/src/zabapedia_object_existence.prog.xml
+++ b/src/zabapedia_object_existence.prog.xml
@@ -3,7 +3,7 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <PROGDIR>
-    <NAME>ZABAPPEDIA_OBJECT_EXISTENCE</NAME>
+    <NAME>ZABAPEDIA_OBJECT_EXISTENCE</NAME>
     <SUBC>1</SUBC>
     <RLOAD>E</RLOAD>
     <FIXPT>X</FIXPT>
@@ -13,13 +13,7 @@
     <item>
      <ID>R</ID>
      <ENTRY>abapPedia Object Existence</ENTRY>
-     <LENGTH>32</LENGTH>
-    </item>
-    <item>
-     <ID>S</ID>
-     <KEY>P_FILE_I</KEY>
-     <ENTRY>Input File Name</ENTRY>
-     <LENGTH>23</LENGTH>
+     <LENGTH>26</LENGTH>
     </item>
     <item>
      <ID>S</ID>
@@ -32,6 +26,12 @@
      <KEY>P_PATH</KEY>
      <ENTRY>Folder</ENTRY>
      <LENGTH>14</LENGTH>
+    </item>
+    <item>
+     <ID>S</ID>
+     <KEY>P_REPO</KEY>
+     <ENTRY>abapedia Repository</ENTRY>
+     <LENGTH>27</LENGTH>
     </item>
    </TPOOL>
   </asx:values>


### PR DESCRIPTION
The program now reads the list of release objects for a given Steampunk release from the corresponding repository on abapedia: https://github.com/orgs/abapedia/repositories?q=steampunk

![image](https://github.com/abapedia/object-existence/assets/59966492/75eaebe5-c435-4576-9e70-f0f89f14bb30)

For example, for Steampunk 2305, the following file is used: https://github.com/abapedia/steampunk-2305-api/blob/main/src/_status.json

The list of objects is filtered by status = "RELEASED" and compared * to the objects existing in this system. Objects with status = "DEPRECATED" are ignored.

The result of the comparison is then saved as a JSON file. The JSON file can then be uploaded for use in abapedia.org to https://github.com/abapedia/object-existence/tree/main/json.